### PR TITLE
Handle falsy pathText in getLastPathValue

### DIFF
--- a/src/pcards.ts
+++ b/src/pcards.ts
@@ -111,13 +111,16 @@ function getWorkItemDefinition(thisWorkItem: Models.WorkItem): IPromise<Models.W
 }
 
 function getLastPathValue(pathText: string): string {
-  if (pathText.length > 0) {
-    let pathArray: string[] = pathText.split("\\");
-    return pathArray[pathArray.length - 1];
+  if (!pathText) {
+    return "";
   }
-  else {
+
+  if (pathText.length === 0) {
     return pathText;
   }
+
+  let pathArray: string[] = pathText.split("\\");
+  return pathArray[pathArray.length - 1];
 }
 
 function prepare(workItems: Models.WorkItem[]) {

--- a/test/TestSpec.js
+++ b/test/TestSpec.js
@@ -1,5 +1,20 @@
-describe('A suite', function () {
-    it('contains spec with an expectation', function () {
-        expect(true).toBe(true);
+describe('getLastPathValue', function () {
+    function getLastPathValue(pathText) {
+        if (!pathText) {
+            return '';
+        }
+        if (pathText.length === 0) {
+            return pathText;
+        }
+        var pathArray = pathText.split('\\');
+        return pathArray[pathArray.length - 1];
+    }
+
+    it('returns the last segment for a defined path', function () {
+        expect(getLastPathValue('a\\b\\c')).toBe('c');
+    });
+
+    it('returns an empty string for undefined input', function () {
+        expect(getLastPathValue(undefined)).toBe('');
     });
 });


### PR DESCRIPTION
## Summary
- avoid calling `.split()` when `pathText` is falsy
- add tests for valid and undefined path values

## Testing
- `node test/TestSpec.js` *(fails: `ReferenceError: describe is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_683ff19b88788325b1fbf78fa345be70