### PR TITLE
Fix typo in details documentation

### DIFF
--- a/details.md
+++ b/details.md
@@ -26,7 +26,7 @@ This Extension supports multi-selecting Work Items, and will print multiple card
     - Iteration
     - Tags
 
-![Printing Multple Cards](static/img/card-print.png)
+![Printing Multiple Cards](static/img/card-print.png)
 
 ## Credits
 


### PR DESCRIPTION
## Summary
- fix spelling of "Multiple" in `details.md`

## Testing
- `npm run lint` *(fails: tslint not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ff19c44c48325b0ad227db0540c14